### PR TITLE
Do not depend on `cargoBuild`

### DIFF
--- a/android-drawable-native/build.gradle.kts
+++ b/android-drawable-native/build.gradle.kts
@@ -70,12 +70,6 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
 }
 
-tasks.whenTaskAdded {
-    when (name) {
-        "mergeDebugJniLibFolders", "mergeReleaseJniLibFolders" -> dependsOn("cargoBuild")
-    }
-}
-
 tasks.register("cargoClean", Exec::class.java) {
     workingDir("$rootDir/giflzwdecoder")
     commandLine("cargo", "clean")


### PR DESCRIPTION
Given `android-drawable-native` being currently broken, calling `gradle assemble` on the project fails as the `cargoBuild` task is missing. I'm removing this dependency.