### PR TITLE
Remove explicit dependency on Kotlin stdlib

### DIFF
--- a/android-drawable-native/build.gradle.kts
+++ b/android-drawable-native/build.gradle.kts
@@ -59,7 +59,6 @@ android {
 
 dependencies {
     api("net.redwarp.gif:decoder:0.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN}")
     implementation("androidx.core:core-ktx:1.3.2")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("com.google.android.material:material:1.2.1")

--- a/android-drawable/build.gradle.kts
+++ b/android-drawable/build.gradle.kts
@@ -54,7 +54,6 @@ android {
 
 dependencies {
     api("net.redwarp.gif:decoder:0.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN}")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,6 @@ android {
 dependencies {
     implementation project(":android-drawable")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$Versions.KOTLIN"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -48,7 +48,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$Versions.KOTLIN"
     implementation project(":android-drawable")
     implementation project(":android-drawable-native")
     implementation "androidx.annotation:annotation:1.1.0"

--- a/decoder/build.gradle.kts
+++ b/decoder/build.gradle.kts
@@ -23,8 +23,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }
 


### PR DESCRIPTION
Explicit dependencies on kotlin-stdlib artifact are unnecessary (unless you want to specifically target a variant of the standard library).

The dependency is added automatically as you add the `kotlin("jvm")` plugin. Ref:  https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library