### PR TITLE
Adds function to create a Gif from another Gif

### DIFF
--- a/decoder/src/main/kotlin/app/redwarp/gif/decoder/Gif.kt
+++ b/decoder/src/main/kotlin/app/redwarp/gif/decoder/Gif.kt
@@ -318,5 +318,7 @@ class Gif(
             inputStream: InputStream,
             pixelPacking: PixelPacking = PixelPacking.ARGB
         ): Result<Gif> = Parser.parse(inputStream, pixelPacking).map(::Gif)
+
+        fun from(gif: Gif): Gif = Gif(gif.gifDescriptor)
     }
 }


### PR DESCRIPTION
Adding a function to be able to clone a Gif. As I'm using Gif directly instead of GifDrawable, I was missing the possibility of being able to clone Gifs. With this I don't need to keep opening a file and creating new Gifs with a manually handled InputStream.

I was not sure if sharing the same InputStream between Gifs was safe or not, but I saw GifDrawable basically doing the same through GifDrawableState(). So I hope I didn't miss anything 😄 

I tried keeping the same convention with a `Git.from()` function, but I am happy to change it in another way if you prefer.
